### PR TITLE
Setting up trycmd to detect CLI example drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,10 +60,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "argminmax"
@@ -157,6 +201,17 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "automod"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb4bd301db2e2ca1f5be131c24eb8ebf2d9559bc3744419e93baf8ddea7e670"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "backtrace"
@@ -356,6 +411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "comfy-table"
 version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +456,15 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -504,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +663,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "flate2"
@@ -869,6 +957,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1237,17 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1229,6 +1344,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "now"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,10 +1428,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db335f4760b14ead6290116f2427bf33a14d4f0617d49f78a246de10c1831224"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "parking"
@@ -2057,6 +2194,7 @@ dependencies = [
  "regex",
  "tempfile",
  "termsize",
+ "trycmd",
 ]
 
 [[package]]
@@ -2479,6 +2617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2709,37 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snapbox"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "libc",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16569f53ca23a41bb6f62e0a5084aa1661f4814a67fa33696a79073e03a664af"
+dependencies = [
+ "anstream",
+]
 
 [[package]]
 name = "socket2"
@@ -2804,6 +2988,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +3099,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trycmd"
+version = "0.15.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b5cf29388862aac065d6597ac9c8e842d1cc827cb50f7c32f11d29442eaae4"
+dependencies = [
+ "anstream",
+ "automod",
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3197,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -3323,6 +3569,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ termsize = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.0"
+trycmd = "0.15"
 
 [lints.clippy]
 # Deny common clippy lints that catch potential bugs or poor practices

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 use crate::cat::CatArgs;
 use crate::head::HeadArgs;
@@ -6,9 +6,23 @@ use crate::join::JoinArgs;
 use crate::query::QueryArgs;
 use crate::tail::TailArgs;
 
+#[derive(ValueEnum, Debug, Clone)]
+pub enum OutputFormat {
+    /// Automatically detect based on terminal (default)
+    Auto,
+    /// Table format output
+    Table,
+    /// CSV format output
+    Csv,
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about = "User-friendly CLI tool for joining tables")]
 pub struct Args {
+    /// Output format
+    #[arg(long, value_enum, default_value = "auto", global = true)]
+    pub format: OutputFormat,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -36,23 +50,23 @@ impl Args {
         match &self.command {
             Commands::Join(join_args) => {
                 join_args.validate()?;
-                join_args.execute()?;
+                join_args.execute(&self.format)?;
             }
             Commands::Cat(cat_args) => {
                 cat_args.validate()?;
-                cat_args.execute()?;
+                cat_args.execute(&self.format)?;
             }
             Commands::Head(head_args) => {
                 head_args.validate()?;
-                head_args.execute()?;
+                head_args.execute(&self.format)?;
             }
             Commands::Query(query_args) => {
                 query_args.validate()?;
-                query_args.execute()?;
+                query_args.execute(&self.format)?;
             }
             Commands::Tail(tail_args) => {
                 tail_args.validate()?;
-                tail_args.execute()?;
+                tail_args.execute(&self.format)?;
             }
         }
         Ok(())

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use std::io;
 
+use crate::args::OutputFormat;
 use crate::io::{read_data, write_data};
 
 #[derive(Args, Debug)]
@@ -18,9 +19,10 @@ impl CatArgs {
     }
 
     #[allow(clippy::expect_used)]
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, format: &OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
         write_data(
             read_data(self.table.as_str(), Some(',')).expect("Failed to read data"),
+            format,
         )?;
 
         Ok(())
@@ -47,7 +49,7 @@ mod tests {
             table: "nonexistent_file.csv".to_string(),
         };
 
-        args.execute().unwrap();
+        args.execute(&crate::args::OutputFormat::Auto).unwrap();
     }
 
     #[test]
@@ -57,6 +59,6 @@ mod tests {
         };
 
         assert!(args.validate().is_ok());
-        assert!(args.execute().is_ok());
+        assert!(args.execute(&crate::args::OutputFormat::Auto).is_ok());
     }
 }

--- a/src/head.rs
+++ b/src/head.rs
@@ -2,6 +2,7 @@
 use clap::Args;
 use std::io;
 
+use crate::args::OutputFormat;
 use crate::io::{read_data, write_data};
 
 #[derive(Args, Debug)]
@@ -23,12 +24,12 @@ impl HeadArgs {
     }
 
     #[allow(clippy::expect_used)]
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, format: &OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
         let data = read_data(self.table.as_str(), Some(',')).expect("Failed to read data");
 
         let head_data = data.head(Some(self.n));
 
-        write_data(head_data)?;
+        write_data(head_data, format)?;
 
         Ok(())
     }
@@ -56,7 +57,7 @@ mod tests {
             n: 5,
         };
 
-        args.execute().unwrap();
+        args.execute(&crate::args::OutputFormat::Auto).unwrap();
     }
 
     #[test]
@@ -67,6 +68,6 @@ mod tests {
         };
 
         assert!(args.validate().is_ok());
-        assert!(args.execute().is_ok());
+        assert!(args.execute(&crate::args::OutputFormat::Auto).is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,10 @@ use io::config;
 
 /// The main entry point that parses CLI arguments and runs the join operation
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Configure Polars table formatting based on terminal dimensions
-    config();
-
     // Parse command line arguments
     let args = Args::parse();
+
+    // Configure Polars table formatting based on terminal dimensions and format option
+    config(&args.format);
     args.run()
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,6 +3,7 @@ use itertools::izip;
 use polars::{prelude::IntoLazy, sql::SQLContext};
 use std::io;
 
+use crate::args::OutputFormat;
 use crate::io::{read_data, write_data};
 
 #[derive(Args, Debug)]
@@ -39,7 +40,7 @@ impl QueryArgs {
         Ok(())
     }
 
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, format: &OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
         let mut ctx = SQLContext::new();
         let names = if self.r#as.is_empty() {
             (0..self.tables.len())
@@ -55,7 +56,7 @@ impl QueryArgs {
 
         let result = ctx.execute(&self.query)?.collect()?;
 
-        write_data(result)?;
+        write_data(result, format)?;
 
         Ok(())
     }
@@ -118,7 +119,7 @@ mod tests {
         assert!(args.validate().is_ok());
 
         // Test that the query executes without error
-        let result = args.execute();
+        let result = args.execute(&crate::args::OutputFormat::Auto);
         assert!(result.is_ok(), "Query execution should succeed");
     }
 
@@ -135,7 +136,7 @@ mod tests {
         assert!(args.validate().is_ok());
 
         // Test that the query executes without error using default table name
-        let result = args.execute();
+        let result = args.execute(&crate::args::OutputFormat::Auto);
         assert!(
             result.is_ok(),
             "Query execution with default table name should succeed"

--- a/src/tail.rs
+++ b/src/tail.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use std::io;
 
+use crate::args::OutputFormat;
 use crate::io::{read_data, write_data};
 
 #[derive(Args, Debug)]
@@ -22,13 +23,13 @@ impl TailArgs {
     }
 
     #[allow(clippy::expect_used)]
-    pub fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(&self, format: &OutputFormat) -> Result<(), Box<dyn std::error::Error>> {
         // TODO: Update read_data to use a circular buffer for better performance
         let data = read_data(self.table.as_str(), Some(',')).expect("Failed to read data");
 
         let tail_data = data.tail(Some(self.n));
 
-        write_data(tail_data)?;
+        write_data(tail_data, format)?;
 
         Ok(())
     }
@@ -56,7 +57,7 @@ mod tests {
             n: 5,
         };
 
-        args.execute().unwrap();
+        args.execute(&crate::args::OutputFormat::Auto).unwrap();
     }
 
     #[test]
@@ -67,6 +68,6 @@ mod tests {
         };
 
         assert!(args.validate().is_ok());
-        assert!(args.execute().is_ok());
+        assert!(args.execute(&crate::args::OutputFormat::Auto).is_ok());
     }
 }

--- a/tests/cat/basic.trycmd
+++ b/tests/cat/basic.trycmd
@@ -1,0 +1,16 @@
+Test cat command with table format output
+
+```console
+$ rabbet cat tests/data/basic/orders.csv
+╭────────────────────────────────────────────────────────────────────────╮
+│ order_id    customer_id    product_id    quantity   price   order_date │
+╞════════════════════════════════════════════════════════════════════════╡
+│ ORDER-001   CUSTOMER-003   PRODUCT-005   1          10.0    2022-01-01 │
+│ ORDER-002   CUSTOMER-003   PRODUCT-005   2          20.0    2022-01-02 │
+│ ORDER-003   CUSTOMER-003   PRODUCT-003   3          30.0    2022-01-03 │
+│ ORDER-004   CUSTOMER-004   PRODUCT-002   4          40.0    2022-01-04 │
+│ ORDER-005   CUSTOMER-005   PRODUCT-001   5          50.0    2022-01-05 │
+│ ORDER-006   CUSTOMER-006   PRODUCT-004   6          60.0    2022-01-06 │
+╰────────────────────────────────────────────────────────────────────────╯
+
+```

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,43 @@
+//! CLI Integration Tests using trycmd
+//!
+//! This module uses trycmd to test CLI commands by running them and comparing
+//! their output against expected snapshots. This ensures that the examples in
+//! our README.md and other documentation remain accurate and functional.
+//!
+//! ## Test Cases
+//!
+//! - `README.md`: Tests the examples in the README, specifically the join and query commands
+//! - `tests/cmd/*.toml`: TOML-based test cases for more complex scenarios
+//! - `tests/cmd/*.trycmd`: Markdown-style test cases (like help commands)
+//!
+//! ## Running Tests
+//!
+//! - `cargo test --test cli_tests` - Run all CLI tests
+//! - `TRYCMD=dump cargo test --test cli_tests` - Generate snapshots for new tests
+//! - `TRYCMD=overwrite cargo test --test cli_tests` - Update existing snapshots
+//!
+//! ## Format Override
+//!
+//! The CLI commands in tests use the default `--format auto` behavior, which is
+//! overridden by environment variables to produce table output even when stdout
+//! is not a terminal. This makes test commands look exactly like what users would
+//! type in real terminals.
+//!
+//! ## Environment Variables
+//!
+//! - `POLARS_TABLE_WIDTH=220`: Set globally for all tests to ensure consistent
+//!   table formatting with improved readability. This provides wider tables with
+//!   full column names instead of truncated versions.
+//! - `RABBET_FORCE_TABLE=1`: Forces table output when using `--format auto` (the
+//!   default), simulating terminal behavior. This eliminates the need for explicit
+//!   `--format table` flags in test commands, making them cleaner and more realistic.
+
+#[test]
+fn cli_tests() {
+    trycmd::TestCases::new()
+        .env("POLARS_TABLE_WIDTH", "220")
+        .env("RABBET_TABLE_OUTPUT", "1")
+        .case("README.md")
+        .case("tests/**/*.toml")
+        .case("tests/**/*.trycmd");
+}

--- a/tests/head/basic.trycmd
+++ b/tests/head/basic.trycmd
@@ -1,0 +1,13 @@
+Test head command with table format output
+
+```console
+$ rabbet head tests/data/basic/orders.csv -n 3
+╭────────────────────────────────────────────────────────────────────────╮
+│ order_id    customer_id    product_id    quantity   price   order_date │
+╞════════════════════════════════════════════════════════════════════════╡
+│ ORDER-001   CUSTOMER-003   PRODUCT-005   1          10.0    2022-01-01 │
+│ ORDER-002   CUSTOMER-003   PRODUCT-005   2          20.0    2022-01-02 │
+│ ORDER-003   CUSTOMER-003   PRODUCT-003   3          30.0    2022-01-03 │
+╰────────────────────────────────────────────────────────────────────────╯
+
+```

--- a/tests/help/help.trycmd
+++ b/tests/help/help.trycmd
@@ -1,0 +1,34 @@
+Test basic help command
+
+```console
+$ rabbet --help
+User-friendly CLI tool for joining tables
+
+Usage: rabbet [OPTIONS] <COMMAND>
+
+Commands:
+  cat    Cat
+  head   Head
+  join   Join
+  query  Query
+  tail   Tail
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+      --format <FORMAT>
+          Output format
+          
+          [default: auto]
+
+          Possible values:
+          - auto:  Automatically detect based on terminal (default)
+          - table: Table format output
+          - csv:   CSV format output
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+```

--- a/tests/join/csv-format.trycmd
+++ b/tests/join/csv-format.trycmd
@@ -1,0 +1,12 @@
+Test join command with CSV format output
+
+```console
+$ rabbet join tests/data/basic/customers.csv tests/data/basic/orders.csv --on customer_id --format csv
+customer_id,customer_name,customer_email,customer_phone,customer_address,customer_city,customer_state,customer_zipcode,customer_country,order_id,product_id,quantity,price,order_date
+CUSTOMER-003,Michael Johnson,michael.johnson@example.com,555-9876,789 Oak St,Anytown,CA,90210,USA,ORDER-001,PRODUCT-005,1,10.0,2022-01-01
+CUSTOMER-003,Michael Johnson,michael.johnson@example.com,555-9876,789 Oak St,Anytown,CA,90210,USA,ORDER-002,PRODUCT-005,2,20.0,2022-01-02
+CUSTOMER-003,Michael Johnson,michael.johnson@example.com,555-9876,789 Oak St,Anytown,CA,90210,USA,ORDER-003,PRODUCT-003,3,30.0,2022-01-03
+CUSTOMER-004,Emily Davis,emily.davis@example.com,555-2468,321 Pine St,Anytown,CA,90210,USA,ORDER-004,PRODUCT-002,4,40.0,2022-01-04
+CUSTOMER-005,Robert Brown,robert.brown@example.com,555-3698,654 Maple St,Anytown,CA,90210,USA,ORDER-005,PRODUCT-001,5,50.0,2022-01-05
+
+```

--- a/tests/join/help.trycmd
+++ b/tests/join/help.trycmd
@@ -1,0 +1,44 @@
+Test join subcommand help
+
+```console
+$ rabbet join --help
+Join
+
+Usage: rabbet join [OPTIONS] <TABLES>...
+
+Arguments:
+  <TABLES>...
+          Input tables (files or '-' for stdin)
+
+Options:
+      --as <AS>
+          Name your tables
+
+      --format <FORMAT>
+          Output format
+          
+          [default: auto]
+
+          Possible values:
+          - auto:  Automatically detect based on terminal (default)
+          - table: Table format output
+          - csv:   CSV format output
+
+      --on <ON>
+          Columns to join on (comma separated)
+
+      --type <TYPE>
+          Type of join to perform
+          
+          [default: inner]
+          [possible values: inner, left, right, outer]
+
+      --delimiter <DELIMITER>
+          Delimiter for input files
+          
+          [default: ,]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+```

--- a/tests/join/left-join.trycmd
+++ b/tests/join/left-join.trycmd
@@ -1,31 +1,12 @@
-# Rabbet
-
-[![CI](https://github.com/rofinn/rabbet/workflows/CI/badge.svg)](https://github.com/rofinn/rabbet/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/rofinn/rabbet/branch/main/graph/badge.svg)](https://codecov.io/gh/rofinn/rabbet)
-
-CLI to simplify shell scripts and glue code operating on relational data.
-
-<p align="center">
-    <img src="./docs/rabbet.svg" alt="Rabbet Joint Diagram" width="400" />
-</p>
-
-## Installation
-
-### From Source
+Test left join between customers and orders
 
 ```console
-$ cargo install --git https://github.com/rofinn/rabbet.git
-```
-
-## Quick Start
-
-Join two CSV files on matching columns:
-
-```console
-$ rabbet join tests/data/basic/customers.csv tests/data/basic/orders.csv --on customer_id
+$ rabbet join tests/data/basic/customers.csv tests/data/basic/orders.csv --on customer_id --type left
 ╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ customer_id    customer_name     customer_email      customer_phone   customer_address   customer_city   customer_state   customer_zipcode   customer_country   order_id    product_id    quantity   price   order_date │
 ╞═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
+│ CUSTOMER-001   John Doe          john.doe@example…   555-1234         123 Main St        Anytown         CA               90210              USA                null        null          null       null    null       │
+│ CUSTOMER-002   Jane Smith        jane.smith@examp…   555-5678         456 Elm St         Anytown         CA               90210              USA                null        null          null       null    null       │
 │ CUSTOMER-003   Michael Johnson   michael.johnson@…   555-9876         789 Oak St         Anytown         CA               90210              USA                ORDER-001   PRODUCT-005   1          10.0    2022-01-01 │
 │ CUSTOMER-003   Michael Johnson   michael.johnson@…   555-9876         789 Oak St         Anytown         CA               90210              USA                ORDER-002   PRODUCT-005   2          20.0    2022-01-02 │
 │ CUSTOMER-003   Michael Johnson   michael.johnson@…   555-9876         789 Oak St         Anytown         CA               90210              USA                ORDER-003   PRODUCT-003   3          30.0    2022-01-03 │
@@ -33,72 +14,4 @@ $ rabbet join tests/data/basic/customers.csv tests/data/basic/orders.csv --on cu
 │ CUSTOMER-005   Robert Brown      robert.brown@exa…   555-3698         654 Maple St       Anytown         CA               90210              USA                ORDER-005   PRODUCT-001   5          50.0    2022-01-05 │
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
-$ rabbet query --as orders tests/data/basic/orders.csv -- "SELECT * FROM orders WHERE product_id = 'PRODUCT-005'"
-╭────────────────────────────────────────────────────────────────────────╮
-│ order_id    customer_id    product_id    quantity   price   order_date │
-╞════════════════════════════════════════════════════════════════════════╡
-│ ORDER-001   CUSTOMER-003   PRODUCT-005   1          10.0    2022-01-01 │
-│ ORDER-002   CUSTOMER-003   PRODUCT-005   2          20.0    2022-01-02 │
-╰────────────────────────────────────────────────────────────────────────╯
-
 ```
-
-This performs an inner join between `tests/data/basic/customers.csv` and `tests/data/basic/orders.csv` on the `customer_id`.
-
-## Development
-
-### Formatting
-
-```console
-$ cargo fmt
-```
-
-### Linting
-
-```console
-$ cargo clippy --fix --allow-dirty
-```
-
-### Running Tests
-
-Run all tests (unit + integration):
-
-```console
-$ cargo test
-```
-
-Run tests with coverage:
-
-```console
-$ cargo llvm-cov
-```
-
-Run only CLI integration tests:
-
-```console
-$ cargo test --test cli_tests
-```
-
-Update CLI test snapshots:
-
-```console
-$ TRYCMD=overwrite cargo test --test cli_tests
-```
-
-### Benchmarking
-
-I don't have any specific benchmarks setup yet, but I haven been comparing against `join` with `hyperfine`.
-
-```console
-$ hyperfine -N --warmup 1 'rabbet join tests/data/basic/orders.csv tests/data/basic/customers.csv --on customer_id'
-```
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request

--- a/tests/join/missing-files.trycmd
+++ b/tests/join/missing-files.trycmd
@@ -1,0 +1,11 @@
+Test join command with missing input files
+
+```console
+$ rabbet join nonexistent1.csv nonexistent2.csv --on id
+? 101
+
+thread 'main' panicked at src/join.rs:101:44:
+Failed to read data: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+```

--- a/tests/query/invalid-sql.trycmd
+++ b/tests/query/invalid-sql.trycmd
@@ -1,0 +1,8 @@
+Test query command with invalid SQL syntax
+
+```console
+$ rabbet query tests/data/basic/orders.csv -- "SELECT * FORM orders"
+? 1
+Error: SQLInterface(ErrString("sql parser error: Expected: end of statement, found: FORM at Line: 1, Column: 10"))
+
+```

--- a/tests/tail/basic.trycmd
+++ b/tests/tail/basic.trycmd
@@ -1,0 +1,13 @@
+Test tail command with table format output
+
+```console
+$ rabbet tail tests/data/basic/orders.csv -n 3
+╭────────────────────────────────────────────────────────────────────────╮
+│ order_id    customer_id    product_id    quantity   price   order_date │
+╞════════════════════════════════════════════════════════════════════════╡
+│ ORDER-004   CUSTOMER-004   PRODUCT-002   4          40.0    2022-01-04 │
+│ ORDER-005   CUSTOMER-005   PRODUCT-001   5          50.0    2022-01-05 │
+│ ORDER-006   CUSTOMER-006   PRODUCT-004   6          60.0    2022-01-06 │
+╰────────────────────────────────────────────────────────────────────────╯
+
+```


### PR DESCRIPTION
- [X] Run on README.md examples (ignoring irrelevant examples)
- [X] Include some examples as integration tests in the `tests` directory
- [X] Match existing expected output

NOTE: I went with `trycmd` over `mdsh` because `clap` itself uses trycmd

Closes #7 